### PR TITLE
#15 don't throw in http, send errors to callback

### DIFF
--- a/lib/braintree/http.coffee
+++ b/lib/braintree/http.coffee
@@ -71,6 +71,9 @@ class Http
           callback(null, null)
       )
     )
+    theRequest.on('error', (err) =>
+        callback(err)
+        )
     theRequest.write(requestBody) if body
     theRequest.end()
 


### PR DESCRIPTION
If there is no remote server, you get an uncaughtException ECONNREFUSED.
