### PR TITLE
Catch HTTP timeouts and other response errors appropriately

### DIFF
--- a/src/braintree/http.coffee
+++ b/src/braintree/http.coffee
@@ -70,6 +70,20 @@ class Http
         else
           callback(null, null)
       )
+
+      response.on('error', (err) ->
+        error = exceptions.UnexpectedError('Unexpected response error: ' + err)
+        return callback(error, null)
+      )
+    )
+
+    theRequest.setTimeout(60000, ->
+      error = exceptions.ServerError()
+      return callback(error, null)
+    )
+    theRequest.on('error', (err) ->
+      error = exceptions.UnexpectedError('Unexpected request error: ' + err)
+      return callback(error, null)
     )
     theRequest.write(requestBody) if body
     theRequest.end()


### PR DESCRIPTION
In node, if the HTTP request times out and the request object does not have a timeout or error handler, an exception is thrown. This patch adds an error response handler and a timeout of 60 seconds. A timeout will return a `ServerError` to the callback. Other response errors, like "socket hang up", will return an `UnexpectedError`.
