### PR TITLE
Objects are not errors

### DIFF
--- a/src/braintree/exceptions.coffee
+++ b/src/braintree/exceptions.coffee
@@ -1,58 +1,70 @@
 errorTypes = require('./error_types')
 
+createError (opts) ->
+  err = new Error()
+  err.message = opts.message
+  Object.defineProperty(err, "type", {
+    value: opts.type,
+    configurable: true,
+    enumerable: true,
+    writable: true
+  })
+  err
+  
+
 AuthenticationError = ->
-  {
+  createError({
     message: 'Authentication Error',
     type: errorTypes.authenticationError
-  }
+  })
 
 AuthorizationError = ->
-  {
+  createError({
     message: 'Authorization Error',
     type: errorTypes.authorizationError
-  }
+  })
 
 DownForMaintenanceError = ->
-  {
+  createError({
     message: 'Down for Maintenance',
     type: errorTypes.downForMaintenanceError
-  }
+  })
 
 InvalidSignatureError = ->
-  {
+  createError({
     message: 'Invalid Signature',
     type: errorTypes.invalidSignatureError
-  }
+  })
 
 InvalidTransparentRedirectHashError = ->
-  {
+  createError({
     message: 'The transparent redirect hash is invalid.',
     type: errorTypes.invalidTransparentRedirectHashError
-  }
+  })
 
 NotFoundError = ->
-  {
+  createError({
     message: 'Not Found',
     type: errorTypes.notFoundError
-  }
+  })
 
 ServerError = ->
-  {
+  createError({
     message: 'Server Error',
     type: errorTypes.serverError
-  }
+  })
 
 UnexpectedError = (message) ->
-  {
+  createError({
     message: message,
     type: errorTypes.unexpectedError
-  }
+  })
 
 UpgradeRequired = ->
-  {
+  createError({
     message: 'This version of the node library is no longer supported.',
     type: errorTypes.upgradeRequired
-  }
+  })
 
 exports.AuthenticationError = AuthenticationError
 exports.AuthorizationError = AuthorizationError


### PR DESCRIPTION
You can't throw objects. You can only throw errors. 

Any parameter passed to the first argument of a `callback` must be an instanceof `Error`

``` js
> throw { message: "str" }
[object Object]
> throw new Error("str")
Error: str
    at repl:1:7
    at REPLServer.self.eval (repl.js:110:21)
    at repl.js:249:20
    at REPLServer.self.eval (repl.js:122:7)
    at Interface.<anonymous> (repl.js:239:12)
    at Interface.EventEmitter.emit (events.js:95:17)
    at Interface._onLine (readline.js:202:10)
    at Interface._line (readline.js:531:8)
    at Interface._ttyWrite (readline.js:760:14)
    at ReadStream.onkeypress (readline.js:99:10)
```
