### PR TITLE
Resolves #21 and #23 -- transaction paging function always grabs first 50 results and uses wrong callback idiom

### DIFF
--- a/src/braintree/transaction_gateway.coffee
+++ b/src/braintree/transaction_gateway.coffee
@@ -73,7 +73,7 @@ class TransactionGateway extends Gateway
 
   pagingFunctionGenerator: (search) ->
     (ids, callback) =>
-      search.ids().contains(ids)
+      search.ids().in(ids)
       @gateway.http.post("/transactions/advanced_search",
         { search : search.toHash() },
         (err, response) ->


### PR DESCRIPTION
Implementation of retrieving transaction details looks like it could use some improvement -- can't really use the current implementation in code.
