### PR TITLE
Required ErrorResponse class

### DIFF
--- a/src/braintree/client_token_gateway.coffee
+++ b/src/braintree/client_token_gateway.coffee
@@ -1,4 +1,5 @@
 {Gateway} = require('./gateway')
+{ErrorResponse} = require('./error_response')
 exceptions = require('./exceptions')
 
 DEFAULT_VERSION = 2


### PR DESCRIPTION
ErrorResponse file was not required in client_token_gateway file which resulted in a ReferenceError
