### PR TITLE
Update semver package per NSP

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "dateformat": "=1.0.1-1.2.3",
     "readable-stream": "=1.1.10",
-    "semver": "=2.2.1",
+    "semver": "=5.1.0",
     "underscore": "=1.3.1",
     "xml2js": "=0.1.13"
   },


### PR DESCRIPTION
Updated `semver` to the latest version in order to remediate [this Node Security Project advisory](https://nodesecurity.io/advisories/31)

Unit tests pass, obviously you'll have to run the integration tests but I don't anticipate there being an issue there.

Cheers!