### PR TITLE
Update NPM dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ lib
 node_modules
 spec_compiled
 tags
+npm-debug*

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "readable-stream": "2.1.2",
     "semver": "5.1.0",
     "underscore": "1.8.3",
-    "xml2js": "0.1.13"
+    "xml2js": "0.4.16"
   },
   "devDependencies": {
     "capture-stream": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "capture-stream": "0.1.2",
     "chai": "1.5.0",
     "coffee-script": "1.6.1",
-    "mocha": "1.6.0"
+    "mocha": "1.6.0",
+    "npm-check-updates": "^2.6.4"
   },
   "optionalDependencies": {
     "source-map-support": "0.2.9"
@@ -39,10 +40,12 @@
   "license": "MIT",
   "scripts": {
     "compile_coffee": "coffee --map -cbo ./lib ./src && coffee --map -cbo ./spec_compiled ./spec",
-    "prepublish": "npm run compile_coffee",
+    "prepublish": "npm run compile_coffee && npm run check_dependencies",
     "test_execute_unit": "mocha spec_compiled/unit --recursive",
     "test_execute_integration": "mocha --slow 2000 spec_compiled/integration --recursive",
     "test_integration": "npm run compile_coffee && npm run test_execute_integration",
-    "test": "npm run compile_coffee && npm run test_execute_unit"
+    "test": "npm run compile_coffee && npm run test_execute_unit",
+    "check_dependencies": "ncu -e 2",
+    "update_dependencies": "ncu -u"
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,22 +20,22 @@
     "node": ">=0.6.6"
   },
   "dependencies": {
-    "dateformat": "1.0.1-1.2.3",
+    "dateformat": "1.0.12",
     "depd": "~1.1.0",
-    "readable-stream": "1.1.10",
+    "readable-stream": "2.1.2",
     "semver": "5.1.0",
-    "underscore": "1.3.1",
+    "underscore": "1.8.3",
     "xml2js": "0.1.13"
   },
   "devDependencies": {
     "capture-stream": "0.1.2",
-    "chai": "1.5.0",
-    "coffee-script": "1.6.1",
-    "mocha": "1.6.0",
+    "chai": "3.5.0",
+    "coffee-script": "1.10.0",
+    "mocha": "2.4.5",
     "npm-check-updates": "^2.6.4"
   },
   "optionalDependencies": {
-    "source-map-support": "0.2.9"
+    "source-map-support": "0.4.0"
   },
   "license": "MIT",
   "scripts": {

--- a/src/braintree/http.coffee
+++ b/src/braintree/http.coffee
@@ -11,6 +11,9 @@ class Http
   constructor: (@config) ->
     @parser = new xml2js.Parser
       explicitRoot: true
+      explicitArray: false
+      attrkey: '@'
+      charkey: '#'
 
   checkHttpStatus: (status) ->
     switch status.toString()

--- a/src/braintree/webhook_notification_gateway.coffee
+++ b/src/braintree/webhook_notification_gateway.coffee
@@ -12,6 +12,9 @@ class WebhookNotificationGateway extends Gateway
     @config = @gateway.config
     @parser = new xml2js.Parser
       explicitRoot: true
+      explicitArray: false
+      attrkey: '@'
+      charkey: '#'
 
   parse: (signature, payload, callback) ->
     if payload.match(/[^A-Za-z0-9+=\/\n]/)


### PR DESCRIPTION
Hello!

I wanted to check out the module, so when running the tests I saw that some dependencies were way out of date. With the recent left-pad debacle, I thought it might not be too presumptuous to submit a PR that adds dependency checking in the `prepublish` script. So that's what 3a52a8e does.

The API of `xml2js` has changed since v0.1.x, so those constructors were changed in 9c36d9c.

Best regards.