### PR TITLE
Export missing PaymentInstrumentTypes

### DIFF
--- a/src/braintree.coffee
+++ b/src/braintree.coffee
@@ -50,6 +50,7 @@ exports.AmexExpressCheckoutCard = AmexExpressCheckoutCard
 exports.CreditCardVerification = CreditCardVerification
 exports.Subscription = Subscription
 exports.MerchantAccount = MerchantAccount
+exports.PaymentInstrumentTypes = PaymentInstrumentTypes
 exports.WebhookNotification = WebhookNotification
 exports.TestingGateway = TestingGateway
 exports.ValidationErrorCodes = ValidationErrorCodes


### PR DESCRIPTION
`PaymentInstrumentTypes` was being imported into the index file but never exported.