### PR TITLE
Updating underscore to 1.8.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "depd": "~1.1.0",
     "readable-stream": "1.1.10",
     "semver": "5.1.0",
-    "underscore": "1.3.1",
+    "underscore": "1.8.3",
     "xml2js": "0.1.13"
   },
   "devDependencies": {


### PR DESCRIPTION
npm v3 is causing issues in resolving peerDependencies, when packages request multiple (old) versions of the same package.  Unfortunately, npm-shrinkwrap.json isn't always an option.

There shouldn't be any breaking changes, the uses of underscore in the repo are:

* _.find
* _.sortBy
* _.each
* _.size
* _.isArray
* _.zip
* _.range
* _.some