### PR TITLE
Support stubbed payloads in the Webhook Testing Gateway

### DIFF
--- a/lib/braintree/subscription.js
+++ b/lib/braintree/subscription.js
@@ -36,7 +36,10 @@ class Subscription extends AttributeSetter {
   constructor(attributes) {
     super(attributes);
 
-    if (attributes.transactions instanceof Array) {
+    if (!attributes.transactions) {
+      this.transactions = [];
+    }
+    else if (attributes.transactions instanceof Array) {
       this.transactions = attributes.transactions.map((transactionAttributes) => {
         return new Transaction(transactionAttributes);
       });

--- a/lib/braintree/subscription.js
+++ b/lib/braintree/subscription.js
@@ -35,9 +35,17 @@ class Subscription extends AttributeSetter {
 
   constructor(attributes) {
     super(attributes);
-    this.transactions = attributes.transactions.map((transactionAttributes) => new Transaction(transactionAttributes));
+
+    if (attributes.transactions instanceof Array) {
+      this.transactions = attributes.transactions.map((transactionAttributes) => {
+        return new Transaction(transactionAttributes);
+      });
+    } else {
+      // this creates an Array of a single element as required to assert transaction using .length method.
+      this.transactions = [].concat(new Transaction(attributes.transactions));
+    }
   }
 }
 Subscription.initClass();
 
-module.exports = { Subscription: Subscription };
+module.exports = {Subscription: Subscription};

--- a/lib/braintree/subscription.js
+++ b/lib/braintree/subscription.js
@@ -40,4 +40,4 @@ class Subscription extends AttributeSetter {
 }
 Subscription.initClass();
 
-module.exports = {Subscription: Subscription};
+module.exports = { Subscription: Subscription };

--- a/lib/braintree/webhook_notification_gateway.js
+++ b/lib/braintree/webhook_notification_gateway.js
@@ -93,6 +93,8 @@ class WebhookNotificationGateway extends Gateway {
   }
 }
 
-module.exports = {WebhookNotificationGateway: wrapPrototype(WebhookNotificationGateway, {
-  ignoreMethods: ['verify']
-})};
+module.exports = {
+  WebhookNotificationGateway: wrapPrototype(WebhookNotificationGateway, {
+    ignoreMethods: ['verify']
+  })
+};

--- a/lib/braintree/webhook_testing_gateway.js
+++ b/lib/braintree/webhook_testing_gateway.js
@@ -6,6 +6,7 @@ let Gateway = require('./gateway').Gateway;
 let WebhookNotification = require('./webhook_notification').WebhookNotification;
 let dateFormat = require('dateformat');
 let wrapPrototype = require('@braintree/wrap-promise').wrapPrototype;
+let js2xmlparser = require("js2xmlparser");
 
 class WebhookTestingGateway extends Gateway {
   constructor(gateway) {
@@ -24,12 +25,43 @@ class WebhookTestingGateway extends Gateway {
     };
   }
 
+  sampleNotificationWithXMLPayload(stubbedXMLPayload) {
+    let payload = new Buffer(this.sampleWithXMLPayload(stubbedXMLPayload)).toString('base64') + '\n';
+    let signature = `${this.gateway.config.publicKey}|${Digest.Sha1hexdigest(this.gateway.config.privateKey, payload)}`;
+
+    return {
+      bt_signature: signature, // eslint-disable-line camelcase
+      bt_payload: payload // eslint-disable-line camelcase
+    };
+  }
+
+  sampleNotificationWithJsonPayload(stubbedJsonPayload) {
+    let payload = new Buffer(this.sampleWithJsonPayload(stubbedJsonPayload)).toString('base64') + '\n';
+    let signature = `${this.gateway.config.publicKey}|${Digest.Sha1hexdigest(this.gateway.config.privateKey, payload)}`;
+
+    return {
+      bt_signature: signature, // eslint-disable-line camelcase
+      bt_payload: payload // eslint-disable-line camelcase
+    };
+  }
+
+  sampleWithXMLPayload(payload) {
+    return `<notification>${payload}</notification>`;
+  }
+
+  sampleWithJsonPayload(payload) {
+    console.log('PAYLOAD: ', payload);
+    let js = `${js2xmlparser.parse('notification', payload)}`;
+    console.log('PARSED PAYLOAD ', js)
+    return js;
+  }
+
   sampleXml(kind, id) {
     return `<notification>
-    <timestamp type="datetime">${dateFormat(new Date(), dateFormat.masks.isoUtcDateTime, true)}</timestamp>
-    <kind>${kind}</kind>
-    <subject>${this.subjectXmlFor(kind, id)}</subject>
-</notification>`;
+        <timestamp type="datetime">${dateFormat(new Date(), dateFormat.masks.isoUtcDateTime, true)}</timestamp>
+        <kind>${kind}</kind>
+        <subject>${this.subjectXmlFor(kind, id)}</subject>
+      </notification>`;
   }
 
   subjectXmlFor(kind, id) { // eslint-disable-line complexity
@@ -352,4 +384,4 @@ class WebhookTestingGateway extends Gateway {
   }
 }
 
-module.exports = {WebhookTestingGateway: wrapPrototype(WebhookTestingGateway)};
+module.exports = { WebhookTestingGateway: wrapPrototype(WebhookTestingGateway) };

--- a/lib/braintree/webhook_testing_gateway.js
+++ b/lib/braintree/webhook_testing_gateway.js
@@ -6,7 +6,7 @@ let Gateway = require('./gateway').Gateway;
 let WebhookNotification = require('./webhook_notification').WebhookNotification;
 let dateFormat = require('dateformat');
 let wrapPrototype = require('@braintree/wrap-promise').wrapPrototype;
-let js2xmlparser = require("js2xmlparser");
+let js2xmlparser = require('js2xmlparser');
 
 class WebhookTestingGateway extends Gateway {
   constructor(gateway) {
@@ -50,10 +50,7 @@ class WebhookTestingGateway extends Gateway {
   }
 
   sampleWithJsonPayload(payload) {
-    console.log('PAYLOAD: ', payload);
-    let js = `${js2xmlparser.parse('notification', payload)}`;
-    console.log('PARSED PAYLOAD ', js)
-    return js;
+    return `${js2xmlparser.parse('notification', payload)}`;
   }
 
   sampleXml(kind, id) {
@@ -384,4 +381,4 @@ class WebhookTestingGateway extends Gateway {
   }
 }
 
-module.exports = { WebhookTestingGateway: wrapPrototype(WebhookTestingGateway) };
+module.exports = {WebhookTestingGateway: wrapPrototype(WebhookTestingGateway)};

--- a/package.json
+++ b/package.json
@@ -20,14 +20,14 @@
     "node": ">=4"
   },
   "dependencies": {
-    "@braintree/wrap-promise": "1.1.1",
     "dateformat": "1.0.1-1.2.3",
     "depd": "~1.1.0",
-    "js2xmlparser": "^3.0.0",
     "readable-stream": "1.1.10",
     "semver": "5.1.0",
     "underscore": "1.8.3",
-    "xml2js": "0.1.13"
+    "xml2js": "0.1.13",
+    "@braintree/wrap-promise": "1.1.1",
+    "js2xmlparser": "^3.0.0"
   },
   "devDependencies": {
     "chai": "1.5.0",

--- a/package.json
+++ b/package.json
@@ -20,13 +20,14 @@
     "node": ">=4"
   },
   "dependencies": {
+    "@braintree/wrap-promise": "1.1.1",
     "dateformat": "1.0.1-1.2.3",
     "depd": "~1.1.0",
+    "js2xmlparser": "^3.0.0",
     "readable-stream": "1.1.10",
     "semver": "5.1.0",
     "underscore": "1.8.3",
-    "xml2js": "0.1.13",
-    "@braintree/wrap-promise": "1.1.1"
+    "xml2js": "0.1.13"
   },
   "devDependencies": {
     "chai": "1.5.0",

--- a/spec/unit/braintree/webhook_notification_gateway_spec.js
+++ b/spec/unit/braintree/webhook_notification_gateway_spec.js
@@ -546,9 +546,6 @@ describe('WebhookNotificationGateway', function () {
       let bt_payload = notification.bt_payload;
 
       specHelper.defaultGateway.webhookNotification.parse(bt_signature, bt_payload, function (err, webhookNotification) {
-        // console.log('notification: ', notification);
-        // console.log('notification with JSON payload: ', JSON.stringify(webhookNotification));
-        // console.log('notification err: ', err);
         assert.equal(webhookNotification.kind, WebhookNotification.Kind.Check);
         done();
       });

--- a/spec/unit/braintree/webhook_notification_gateway_spec.js
+++ b/spec/unit/braintree/webhook_notification_gateway_spec.js
@@ -532,10 +532,10 @@ describe('WebhookNotificationGateway', function () {
   describe('stubbed notification', function () {
     it('returns a parsable signature with the provided JSON payload', function (done) {
       const payload = {
-        "timestamp": dateFormat(new Date(), dateFormat.masks.isoUtcDateTime, true),
-        "kind": WebhookNotification.Kind.Check,
-        "subject": {
-          "check": true
+        timestamp: dateFormat(new Date(), dateFormat.masks.isoUtcDateTime, true),
+        kind: WebhookNotification.Kind.Check,
+        subject: {
+          check: true
         }
       };
 
@@ -556,42 +556,42 @@ describe('WebhookNotificationGateway', function () {
 
     it('returns a parsable signature with the provided complex JSON payload', function (done) {
       const payload = {
-        "timestamp": dateFormat(new Date(), dateFormat.masks.isoUtcDateTime, true),
-        "kind": WebhookNotification.Kind.SubscriptionChargedSuccessfully,
-        "subject": {
-          "subscription": {
-            "id": "mySubscription",
-            "transactions": [
+        timestamp: dateFormat(new Date(), dateFormat.masks.isoUtcDateTime, true),
+        kind: WebhookNotification.Kind.SubscriptionChargedSuccessfully,
+        subject: {
+          subscription: {
+            id: 'mySubscription',
+            transactions: [
               {
-                "status": "submitted_for_settlement",
-                "amount": "49.99"
+                status: 'submitted_for_settlement',
+                amount: '49.99'
               }
             ],
-            "addOns": [],
-            "discounts": []
+            addOns: [],
+            discounts: []
           }
         },
-        "subscription": {
-          "id": "mySubscription",
-          "transactions": [
+        subscription: {
+          id: 'mySubscription',
+          transactions: [
             {
-              "status": "submitted_for_settlement",
-              "amount": "49.99",
-              "creditCard": {
-                "maskedNumber": "undefined******undefined",
-                "expirationDate": "undefined/undefined"
+              status: 'submitted_for_settlement',
+              amount: '49.99',
+              creditCard: {
+                maskedNumber: 'undefined******undefined',
+                expirationDate: 'undefined/undefined'
               },
-              "paypalAccount": {},
-              "coinbaseAccount": {},
-              "applePayCard": {},
-              "androidPayCard": {},
-              "disbursementDetails": {},
-              "visaCheckoutCard": {},
-              "masterpassCard": {}
+              paypalAccount: {},
+              coinbaseAccount: {},
+              applePayCard: {},
+              androidPayCard: {},
+              disbursementDetails: {},
+              visaCheckoutCard: {},
+              masterpassCard: {}
             }
           ],
-          "addOns": [],
-          "discounts": []
+          addOns: [],
+          discounts: []
         }
       };
 
@@ -602,9 +602,6 @@ describe('WebhookNotificationGateway', function () {
       let bt_payload = notification.bt_payload;
 
       specHelper.defaultGateway.webhookNotification.parse(bt_signature, bt_payload, function (err, webhookNotification) {
-        console.log('NOTIFICATION: ', notification);
-        console.log('WEBHOOK NOTIFICATION: ', JSON.stringify(webhookNotification));
-        console.log('ERR: ', err);
         assert.equal(webhookNotification.kind, WebhookNotification.Kind.SubscriptionChargedSuccessfully);
         assert.equal(webhookNotification.subscription.id, 'mySubscription');
         assert.equal(webhookNotification.subscription.transactions.length, 1);
@@ -618,10 +615,10 @@ describe('WebhookNotificationGateway', function () {
     });
 
     it('returns a parsable signature with the provided XML payload', function (done) {
-      const payload = `<timestamp type="datetime">${dateFormat(new Date(), dateFormat.masks.isoUtcDateTime, true)}</timestamp>
+      const payload = `<timestamp type='datetime'>${dateFormat(new Date(), dateFormat.masks.isoUtcDateTime, true)}</timestamp>
         <kind>${WebhookNotification.Kind.Check}</kind>
         <subject>
-          <check type="boolean">true</check>
+          <check type='boolean'>true</check>
         </subject>`;
 
       let notification = specHelper.defaultGateway.webhookTesting.sampleNotificationWithXMLPayload(
@@ -631,10 +628,57 @@ describe('WebhookNotificationGateway', function () {
       let bt_payload = notification.bt_payload;
 
       specHelper.defaultGateway.webhookNotification.parse(bt_signature, bt_payload, function (err, webhookNotification) {
-        // console.log('notification: ', notification);
-        // console.log('notification with JSON payload: ', JSON.stringify(webhookNotification));
-        // console.log('notification err: ', err);
         assert.equal(webhookNotification.kind, WebhookNotification.Kind.Check);
+        done();
+      });
+    });
+
+    it('returns a parsable signature with the provided complex XML payload', function (done) {
+      const payload = `<timestamp>${dateFormat(new Date(), dateFormat.masks.isoUtcDateTime, true)}</timestamp>
+      <kind>${WebhookNotification.Kind.SubscriptionChargedSuccessfully}</kind>
+      <subject>
+        <subscription>
+          <id>mySubscription</id>
+          <transactions>
+            <status>submitted_for_settlement</status>
+            <amount>49.99</amount>
+          </transactions>
+        </subscription>
+      </subject>
+      <subscription>
+        <id>mySubscription</id>
+        <transactions>
+          <status>submitted_for_settlement</status>
+          <amount>49.99</amount>
+          <creditCard>
+            <maskedNumber>undefined******undefined</maskedNumber>
+            <expirationDate>undefined/undefined</expirationDate>
+          </creditCard>
+          <paypalAccount />
+          <coinbaseAccount />
+          <applePayCard />
+          <androidPayCard />
+          <disbursementDetails />
+          <visaCheckoutCard />
+          <masterpassCard />
+        </transactions>
+      </subscription>`;
+
+      let notification = specHelper.defaultGateway.webhookTesting.sampleNotificationWithXMLPayload(
+        payload
+      );
+      let bt_signature = notification.bt_signature;
+      let bt_payload = notification.bt_payload;
+
+      specHelper.defaultGateway.webhookNotification.parse(bt_signature, bt_payload, function (err, webhookNotification) {
+        assert.equal(webhookNotification.kind, WebhookNotification.Kind.SubscriptionChargedSuccessfully);
+        assert.equal(webhookNotification.subscription.id, 'mySubscription');
+        assert.equal(webhookNotification.subscription.transactions.length, 1);
+
+        let transaction = webhookNotification.subscription.transactions.pop();
+
+        assert.equal(transaction.status, 'submitted_for_settlement');
+        assert.equal(transaction.amount, 49.99);
         done();
       });
     });


### PR DESCRIPTION
# Summary
Support providing custom notification payloads to the Testing Gateway enabling more comprehensive and production ready testing capabilities.

# Details
* A JS -> XML parser was required to support both JSON and XML payloads to be provided. The `xml2js` lib provides this in a newer version than used, but updating breaks most test cases so I added the `js2xmlparser` library for this.
* `lib/braintree/subscription.js` was edited to handle non-array transaction attributes. This was necessary because of the JS -> XML lib discussed above. It does not add type attributes to XML tags, thus the array attributes with single elements lose their `array` attribute. The array is required to do `.length` assertions in testing.
* a simple and complex payload example was provided for the new JSON and XML notification producers.

This should provide a solution to #97 

@braintreeps If the format of passing the entire notification is not optimal I am more than happy to split this into NotificationKind and payload. Although the section of the payload outside of the `subject` element seems important.

# Checklist
- [ ] Added changelog entry
- [x] Ran unit tests (`npm test`)
