### PR TITLE
Update util.js

### DIFF
--- a/lib/braintree/util.js
+++ b/lib/braintree/util.js
@@ -261,7 +261,7 @@ class Util {
     }
 
     if (invalidKeys.length > 0) {
-      return exceptions.InvalidKeysError(`These keys are invalid: ${invalidKeys.join(', ')}`); // eslint-disable-line new-cap
+      return exceptions.InvalidKeysError(`These custom fields are invalid: ${invalidKeys.join(', ')}`); // eslint-disable-line new-cap
     }
   }
 

--- a/lib/braintree/util.js
+++ b/lib/braintree/util.js
@@ -261,7 +261,7 @@ class Util {
     }
 
     if (invalidKeys.length > 0) {
-      return exceptions.InvalidKeysError(`These custom fields are invalid: ${invalidKeys.join(', ')}`); // eslint-disable-line new-cap
+      return exceptions.InvalidKeysError(`These properties are invalid: ${invalidKeys.join(', ')}`); // eslint-disable-line new-cap
     }
   }
 


### PR DESCRIPTION
Improve error message when custom field is not correct.
`KeysError` is usually referred to private/public keys errors, "custom fields" is more developer friendly, IMHO.

# Summary

# Checklist

- [ ] Added changelog entry
- [ ] Ran unit tests (`npm test`)

<!-- **For Braintree Developers only, don't forget:**
- [ ] Does this change require work to be done to the GraphQL API? If you have questions check with the GraphQL team.
- [ ] Add & Run integration tests -->
