### PR TITLE
Exposes the exceptions defined in exceptions.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Unreleased
+* Add exceptions defined in `exceptions.js` as an export
+
 ## 3.1.0
 - Add `AcquirerReferenceNumber` to `Transaction`
 - Deprecate `recurring` in `transaction.sale()` requests

--- a/lib/braintree.js
+++ b/lib/braintree.js
@@ -5,6 +5,7 @@ let Environment = require('./braintree/environment').Environment;
 let BraintreeGateway = require('./braintree/braintree_gateway').BraintreeGateway;
 let GraphQL = require('./braintree/graphql').GraphQL;
 let errorTypes = require('./braintree/error_types').errorTypes;
+let exceptions = require('./braintree/exceptions');
 
 let Transaction = require('./braintree/transaction').Transaction;
 
@@ -47,6 +48,7 @@ module.exports = {
   version: version,
   Environment: Environment,
   errorTypes: errorTypes,
+  exceptions: exceptions,
 
   Transaction: Transaction,
 


### PR DESCRIPTION
# Summary
Only the `errorTypes` dictionary is currently available under the `braintree` export. This makes the `braintree.exceptions` namespace available, as [defined in the documentation](https://developers.braintreepayments.com/reference/general/exceptions/node).

# Checklist

- [x] Added changelog entry
- [x] Ran unit tests (`npm test`)

<!-- **For Braintree Developers only, don't forget:**
- [ ] Does this change require work to be done to the GraphQL API? If you have questions check with the GraphQL team.
- [ ] Add & Run integration tests -->
